### PR TITLE
Small changes to import persons

### DIFF
--- a/persons.ps1
+++ b/persons.ps1
@@ -88,14 +88,14 @@ function Get-HR2DayEmployeeData {
                 $endDate = "$($endDateYear)0101"
                 $splatParams['Endpoint']="arbeidsrelatie?wg=$WG_Employees&dateFrom=$startDate&dateTo=$endDate"
                 $arbeidsRelatieData = Invoke-HR2DayRestMethod @splatParams
-                $resultArray.add($arbeidsRelatieData) | Out-Null
+                $resultArray.AddRange($arbeidsRelatieData) | Out-Null
                 $startRange--
-            } until ($startRange -eq 0)
-                $startDate = "$($currentYear.ToString("yyyy"))0101"
-                $endDate = (Get-Date -Month 12 -Day 31).ToString("yyyyMMdd")
-                $splatParams['Endpoint']="arbeidsrelatie?wg=$WG_Employees&dateFrom=$startDate&dateTo=$endDate"
-                $arbeidsRelatieData = Invoke-HR2DayRestMethod @splatParams
-                $resultArray.add($arbeidsRelatieData) | Out-Null
+            } until ($startRange -eq -1)
+                # $startDate = "$($currentYear.ToString("yyyy"))0101"
+                # $endDate = (Get-Date -Month 12 -Day 31).ToString("yyyyMMdd")
+                # $splatParams['Endpoint']="arbeidsrelatie?wg=$WG_Employees&dateFrom=$startDate&dateTo=$endDate"
+                # $arbeidsRelatieData = Invoke-HR2DayRestMethod @splatParams
+                # $resultArray.add($arbeidsRelatieData) | Out-Null
         } else {
             $splatParams['Endpoint']="arbeidsrelatie?wg=$WG_Employees"
             $arbeidsRelatieData = Invoke-HR2DayRestMethod @splatParams
@@ -105,10 +105,12 @@ function Get-HR2DayEmployeeData {
             throw 'Could not retrieve arbeidsrelatiedata, the result exceeds the limit'
         } else {
             Write-Verbose 'Combining Employee and Arbeidsrelaties data'
-            $contractDelegate = [Func[object, object]] {
-                param ($contract) $contract.hr2d__Employee__c
-            }
-            $lookup = [Linq.Enumerable]::ToLookup($arbeidsRelatieData, $contractDelegate)
+            # $contractDelegate = [Func[object, object]] {
+            #     param ($contract) $contract.hr2d__Employee__c
+            # }
+            # $lookup = [Linq.Enumerable]::ToLookup($arbeidsRelatieData, $contractDelegate)
+            $lookup = $resultArray | Group-Object -AsHashTable -Property hr2d__Employee__c
+
 
             [System.Collections.Generic.List[object]]$resultList = @()
             foreach ($employee in $employeeData){


### PR DESCRIPTION
On line 91 the add function caused $resultArray to add new array objects to it. This would not work with line 112 because it expected an array with objects items with property hr2d__Employee__c.

Line 94 to 98 where redundant. This piece of code is a copy of what is in the do{}until loop. I changed the value of the until from 0 to -1. 

Line 108 to 111 was not working with the correct dataset. It was working with $arbeidsRelatieData instead of the resultArray.